### PR TITLE
Rename :db_migrations_location to :migrations_location

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,7 @@ base_config = SequelTools.base_config(
   dump_schema_on_migrate: false, # it's a good idea to enable it for the reference environment
   pg_dump: 'pg_dump', # command used to run pg_dump
   pg_dump: 'psql', # command used to run psql when calling rake db:shell if adapter is postgres
-  db_migrations_location: 'db/migrations',
+  migrations_location: 'db/migrations',
   schema_location: 'db/migrations/schema.sql',
   seeds_location: 'db/seeds.rb',
   maintenancedb: 'postgres' # for tasks such as creating the database

--- a/lib/sequel_tools.rb
+++ b/lib/sequel_tools.rb
@@ -8,7 +8,7 @@ module SequelTools
     pg_dump: 'pg_dump', # command used to run pg_dump
     psql: 'psql', # command used to run psql
     maintenancedb: 'postgres', # DB to connect to for creating/dropping databases
-    db_migrations_location: 'db/migrations',
+    migrations_location: 'db/migrations',
     schema_location: 'db/migrations/schema.sql',
     seeds_location: 'db/seeds.rb',
     dbname: nil,
@@ -29,7 +29,7 @@ module SequelTools
     REQUIRED_KEYS.each do |key|
       raise MissingConfigError, "Expected value for #{key} config is missing" if config[key].nil?
     end
-    [:db_migrations_location, :schema_location, :seeds_location].each do |k|
+    [:migrations_location, :schema_location, :seeds_location].each do |k|
       config[k] = File.expand_path config[k], config[:project_root]
     end
     config

--- a/lib/sequel_tools/actions/migrate.rb
+++ b/lib/sequel_tools/actions/migrate.rb
@@ -12,7 +12,7 @@ class SequelTools::ActionsManager
     Sequel.extension :migration unless Sequel.respond_to? :migration
     options = {}
     options[:target] = args[:version].to_i if args[:version]
-    Sequel::Migrator.run db, config[:db_migrations_location], options
+    Sequel::Migrator.run db, config[:migrations_location], options
     Action[:schema_dump].run({}, context) if config[:dump_schema_on_migrate]
   end
 end

--- a/lib/sequel_tools/actions/new_migration.rb
+++ b/lib/sequel_tools/actions/new_migration.rb
@@ -7,7 +7,7 @@ class SequelTools::ActionsManager
   Action.register :new_migration, desc, arg_names: [ :name ] do |args, context|
     (puts 'Migration name is missing - aborting'; exit 1) unless name = args[:name]
     require 'time'
-    migrations_path = context[:config][:db_migrations_location]
+    migrations_path = context[:config][:migrations_location]
     filename = "#{migrations_path}/#{Time.now.strftime '%Y%m%d%H%M%S'}_#{name}.rb"
     File.write filename, <<~MIGRATIONS_TEMPLATE_END
       # documentation available at http://sequel.jeremyevans.net/rdoc/files/doc/migration_rdoc.html

--- a/lib/sequel_tools/actions/status.rb
+++ b/lib/sequel_tools/actions/status.rb
@@ -8,7 +8,7 @@ class SequelTools::ActionsManager
   description = 'Show migrations status (applied and missing in migrations path vs unapplied)'
   Action.register :status, description do |args, context|
     unapplied, files_missing = MigrationUtils.migrations_differences context
-    path = context[:config][:db_migrations_location]
+    path = context[:config][:migrations_location]
     unless files_missing.empty?
       puts "The following migrations were applied to the database but can't be found in #{path}:"
       puts files_missing.map{|fn| "  - #{fn}" }.join("\n")

--- a/lib/sequel_tools/migration_utils.rb
+++ b/lib/sequel_tools/migration_utils.rb
@@ -22,8 +22,8 @@ class MigrationUtils
     options = { allow_missing_migration_files: true }
     options[:target] = 0 if direction == :down
     config = context[:config]
-    Sequel::Migrator.migrator_class(config[:db_migrations_location]).
-      new(context[:db], config[:db_migrations_location], options)
+    Sequel::Migrator.migrator_class(config[:migrations_location]).
+      new(context[:db], config[:migrations_location], options)
   end
 
   def self.current_version(context)
@@ -32,7 +32,7 @@ class MigrationUtils
   end
 
   def self.last_found_migration(context)
-    migrations_path = context[:config][:db_migrations_location]
+    migrations_path = context[:config][:migrations_location]
     migrator = find_migrator(context)
     migrator.ds.order(Sequel.desc(migrator.column)).select_map(migrator.column).find do |fn|
       File.exist?("#{migrations_path}/#{fn}")
@@ -41,7 +41,7 @@ class MigrationUtils
 
   def self.migrations_differences(context)
     config = context[:config]
-    migrations_path = config[:db_migrations_location]
+    migrations_path = config[:migrations_location]
     existing = Dir["#{migrations_path}/*.rb"].map{|fn| File.basename fn }.sort
     migrator = find_migrator context
     migrated = migrator.ds.select_order_map(migrator.column)

--- a/spec/sequel_tools_spec.rb
+++ b/spec/sequel_tools_spec.rb
@@ -16,7 +16,7 @@ RSpec.describe SequelTools do
     it 'returns a basic configuration given the minimum required information' do
       config = SequelTools.base_config project_root: '/project_root', dbadapter: 'postgres',
         dbname: 'mydb', username: 'myuser'
-      expect(config[:db_migrations_location]).to eq '/project_root/db/migrations'
+      expect(config[:migrations_location]).to eq '/project_root/db/migrations'
       expect(config[:schema_location]).to eq '/project_root/db/migrations/schema.sql'
       expect(config[:seeds_location]).to eq '/project_root/db/seeds.rb'
     end


### PR DESCRIPTION
This makes the naming consistent with `:schema_location` and `:seeds_location` options.

What do you think?