### PR TITLE
Simplify setup

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,16 @@ And then execute:
 
 ## Usage
 
+The simplest way to get started:
+
+```rb
+require 'sequel_tools'
+
+namespace :db do
+  SequelTools.inject_rake_tasks Hash[db_url: 'postgres://username:password@localhost/dbname'], self
+end
+```
+
 Here's a sample Rakefile supporting migrate actions:
 
 ```ruby


### PR DESCRIPTION
This pull request is a compilation of changes that aim to reduce friction when configuring rake tasks.

I found out that, when `rake` is called from a subdirectory, `Dir.pwd` will still point to the directory containing the rakefile. This is because Rake internally uses `Dir.chdir`, which updates `Dir.pwd`. This means we don't need to require `:project_root` anymore, we can default to `Dir.pwd`.

Next, it would be convenient if there was no need to call `SequelTools.base_config`, for cases when development & test databases don't share common configuration, or there is only one set of rake tasks. Currently, `Sequel.base_config` requires `:dbname` and `:username` to be passed in, but those will almost always be different between databases. We achieve this by calling `SequelTools.base_config` from `SequelTools.inject_rake_tasks`.

Finally, following up to https://github.com/rosenfeld/sequel_tools/issues/2, we add a `:db_url` option, which allows specifying a database URL instead of database options. It's common for applications to have database URLs in their application config, so this should be most convenient. We also don't use any private Sequel APIs. I chose not to support passing `Sequel::Database` objects, because for `db:drop` to work there shouldn't be any open connections, so I didn't want people to be able to fall into that trap.
