### PR TITLE
Generate correct database URL with SQLite adapter

### DIFF
--- a/lib/sequel_tools/actions_manager.rb
+++ b/lib/sequel_tools/actions_manager.rb
@@ -9,9 +9,10 @@ module SequelTools
       uri_parts = []
       uri_parts << 'jdbc:' if RUBY_PLATFORM == 'java'
       uri_parts << "#{c[:jdbc_adapter] || c[:dbadapter]}://"
-      uri_parts << c[:dbhost]
+      uri_parts << c[:dbhost] unless c[:dbadapter] == 'sqlite'
       uri_parts << ':' << c[:dbport] if c[:dbport]
-      uri_parts << '/' << dbname
+      uri_parts << '/' unless c[:dbadapter] == 'sqlite'
+      uri_parts << dbname
       if user = c[:username]
         uri_parts << '?user=' << user
         uri_parts << '&password=' << c[:password] if c[:password]


### PR DESCRIPTION
Currently, the database URL that's generated isn't valid:

```
sqlite://localhost/db.sqlite3
```

This PR fixes it to remove the host and extra slash:

```
sqlite://db.sqlite3
```

I know tests are missing, but I haven't managed to set up the PG databases correctly to make the existing tests green. Is there a script I can run to set it all up, something like [Rodauth's rake tasks](https://github.com/jeremyevans/rodauth/blob/7ee1672d71f0ace2cb3c8a23925cbdab61b54918/Rakefile#L101-L117)?
