### PR TITLE
Make `:username` optional configuration argument

### DIFF
--- a/lib/sequel_tools.rb
+++ b/lib/sequel_tools.rb
@@ -24,7 +24,7 @@ module SequelTools
     extra_tables_in_dump: nil,
   } # unfrozen on purpose so that one might want to update the defaults
 
-  REQUIRED_KEYS = [ :dbadapter, :dbname, :username ]
+  REQUIRED_KEYS = [ :dbadapter, :dbname ]
   class MissingConfigError < StandardError; end
   def self.base_config(extra_config = {})
     config = DEFAULT_CONFIG.merge extra_config


### PR DESCRIPTION
When developing locally on Postgres and SQLite, it's common to rely on the default username and have no password, which happens when we create the database with `createdb mydatabase` on Postgres (on SQLite it's the norm). So, it would be convenient not to have to pass the username. It seems that the database URL generator is already handling the scenario of `:username` being `nil`.

This was extracted from https://github.com/rosenfeld/sequel_tools/pull/5.
